### PR TITLE
chore: improve node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
   "module": "dist/opfs-tools.js",
   "main": "dist/opfs-tools.umd.cjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/opfs-tools.js",
+      "require": "./dist/opfs-tools.umd.cjs"
+    }
+  },
   "scripts": {
     "dev": "vite demo",
     "test": "vitest",


### PR DESCRIPTION
@hughfenghen First of all, thanks for making this lib. 

While integrating it with a project I work on I found that my playwright tests are failing due to limited support of ES modules in Playwright. The solution however it quite simple and required only additional paths definion in `package.json` under `exports`. I hope it won't be a problem for merging it and releasing new version. 

I wish you all the best and send my greetings from Poland :)